### PR TITLE
Compatibility with older go version

### DIFF
--- a/op/handlers.go
+++ b/op/handlers.go
@@ -14,9 +14,7 @@ func newHealthCheckHandler(hc *Status) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
-		enc := json.NewEncoder(w)
-		enc.SetIndent("  ", "  ")
-		if err := enc.Encode(hc.Check()); err != nil {
+		if err := newEncoder(w).Encode(hc.Check()); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 	})

--- a/op/json.go
+++ b/op/json.go
@@ -1,0 +1,14 @@
+// +build go1.7
+
+package op
+
+import (
+	"encoding/json"
+	"io"
+)
+
+func newEncoder(w io.Writer) *json.Encoder {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("  ", "  ")
+	return enc
+}

--- a/op/json16.go
+++ b/op/json16.go
@@ -1,0 +1,13 @@
+// +build !go1.7
+
+package op
+
+import (
+	"encoding/json"
+	"io"
+)
+
+func newEncoder(w io.Writer) *json.Encoder {
+	enc := json.NewEncoder(w)
+	return enc
+}


### PR DESCRIPTION
Before 1.7, SetIndent() was not available for the JSON encoder. To
enable compatability with older versions of go, we simply skip the
JSON indenting in 1.6.x and below.

This is probably temporary until 1.6 use dies out.

Note that the unit tests do not pass on go versions before 1.7 because
they expect the JSON to be nicely indented.  I don't intend to fix this,
but patches welcome if anyone else cares enough.