### PR TITLE
Add metering of healthchecks to be used by consumers later

### DIFF
--- a/op/health_with_metrics_test.go
+++ b/op/health_with_metrics_test.go
@@ -12,15 +12,15 @@ func TestHealthCheckWithMetrics(t *testing.T) {
 	assert := assert.New(t)
 
 	hc := NewStatus("my app", "app description").
-		AddCheckerWithMetrics("check the foo bar", func(cr *CheckResponse) {
+		AddChecker("check the foo bar", func(cr *CheckResponse) {
 			cr.Healthy("check command completed ok")
 		}).
-		AddCheckerWithMetrics("check the unhealthy one", func(cr *CheckResponse) {
+		AddChecker("check the unhealthy one", func(cr *CheckResponse) {
 			cr.Unhealthy("thing failed", "fix the thing", "very bad")
 		}).
-		AddCheckerWithMetrics("check the bar baz", func(cr *CheckResponse) {
+		AddChecker("check the bar baz", func(cr *CheckResponse) {
 			cr.Degraded("thing failed", "fix the thing")
-		})
+		}).WithInstrumentedChecks()
 
 	expected := HealthResult{
 		Name:        "my app",
@@ -54,30 +54,38 @@ func TestHealthCheckWithMetrics(t *testing.T) {
 	result := hc.Check()
 	assert.Equal(expected, result)
 	mfs, _ := prometheus.DefaultGatherer.Gather()
-	checkAssertion(t, mfs, "check_the_foo_bar", healthy, 1)
-	checkAssertion(t, mfs, "check_the_bar_baz", degraded, 1)
-	checkAssertion(t, mfs, "check_the_unhealthy_one", unhealthy, 1)
+	assertMetricLabelsAndValue(t, mfs, "check_the_foo_bar", healthy, 1)
+	assertMetricLabelsAndValue(t, mfs, "check_the_bar_baz", degraded, 1)
+	assertMetricLabelsAndValue(t, mfs, "check_the_unhealthy_one", unhealthy, 1)
 
 	// Check that the metrics are actually incrementing
 	hc.Check()
 	mfs, _ = prometheus.DefaultGatherer.Gather()
-	checkAssertion(t, mfs, "check_the_foo_bar", healthy, 2)
-	checkAssertion(t, mfs, "check_the_bar_baz", degraded, 2)
-	checkAssertion(t, mfs, "check_the_unhealthy_one", unhealthy, 2)
+	assertMetricLabelsAndValue(t, mfs, "check_the_foo_bar", healthy, 2)
+	assertMetricLabelsAndValue(t, mfs, "check_the_bar_baz", degraded, 2)
+	assertMetricLabelsAndValue(t, mfs, "check_the_unhealthy_one", unhealthy, 2)
 }
 
-func checkAssertion(t *testing.T, mfs []*dto.MetricFamily, checkname string, outcome string, value int) {
+func assertMetricLabelsAndValue(t *testing.T, mfs []*dto.MetricFamily, checkname string, outcome string, value int) {
 	for _, mf := range mfs {
-		if mf.GetName() == checkname && mf.GetType() == dto.MetricType_COUNTER {
-			for _, x := range mf.Metric {
-				assert.Equal(t, float64(value), x.GetCounter().GetValue())
-
-				for _, label := range x.Label {
-					if *label.Name == "healthcheck_result" {
-						assert.Equal(t, outcome, *label.Value)
+		if mf.GetName() == healthcheckStatus && mf.GetType() == dto.MetricType_COUNTER {
+			for _, metric := range mf.Metric {
+				matchedName, matchedResult := false, false
+				for _, metricLabel := range metric.GetLabel() {
+					if metricLabel.GetName() == healthcheckName && metricLabel.GetValue() == checkname {
+						matchedName = true
 					}
+					if metricLabel.GetName() == healthcheckResult && metricLabel.GetValue() == outcome {
+						matchedResult = true
+					}
+				}
+
+				if matchedName && matchedResult {
+					assert.Equal(t, float64(value), metric.GetCounter().GetValue())
+					return
 				}
 			}
 		}
 	}
+	assert.Fail(t, "Expected counter to match labels and count, but nt")
 }

--- a/op/health_with_metrics_test.go
+++ b/op/health_with_metrics_test.go
@@ -1,0 +1,83 @@
+package op
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestHealthCheckWithMetrics(t *testing.T) {
+	assert := assert.New(t)
+
+	hc := NewStatus("my app", "app description").
+		AddCheckerWithMetrics("check the foo bar", func(cr *CheckResponse) {
+			cr.Healthy("check command completed ok")
+		}).
+		AddCheckerWithMetrics("check the unhealthy one", func(cr *CheckResponse) {
+			cr.Unhealthy("thing failed", "fix the thing", "very bad")
+		}).
+		AddCheckerWithMetrics("check the bar baz", func(cr *CheckResponse) {
+			cr.Degraded("thing failed", "fix the thing")
+		})
+
+	expected := HealthResult{
+		Name:        "my app",
+		Description: "app description",
+		Health:      "unhealthy",
+		CheckResults: []healthResultEntry{
+			{
+				Name:   "check the foo bar",
+				Health: "healthy",
+				Output: "check command completed ok",
+				Action: "",
+				Impact: "",
+			},
+			{
+				Name:   "check the unhealthy one",
+				Health: "unhealthy",
+				Output: "thing failed",
+				Action: "fix the thing",
+				Impact: "very bad",
+			},
+			{
+				Name:   "check the bar baz",
+				Health: "degraded",
+				Output: "thing failed",
+				Action: "fix the thing",
+				Impact: "",
+			},
+		},
+	}
+
+	result := hc.Check()
+	assert.Equal(expected, result)
+	mfs, _ := prometheus.DefaultGatherer.Gather()
+	checkAssertion(t, mfs, "check_the_foo_bar", healthy, 1)
+	checkAssertion(t, mfs, "check_the_bar_baz", degraded, 1)
+	checkAssertion(t, mfs, "check_the_unhealthy_one", unhealthy, 1)
+
+	// Check that the metrics are actually incrementing
+	hc.Check()
+	mfs, _ = prometheus.DefaultGatherer.Gather()
+	checkAssertion(t, mfs, "check_the_foo_bar", healthy, 2)
+	checkAssertion(t, mfs, "check_the_bar_baz", degraded, 2)
+	checkAssertion(t, mfs, "check_the_unhealthy_one", unhealthy, 2)
+}
+
+func checkAssertion(t *testing.T, mfs []*dto.MetricFamily, checkname string, outcome string, value int) {
+	for _, mf := range mfs {
+		if mf.GetName() == checkname && mf.GetType() == dto.MetricType_COUNTER {
+			for _, x := range mf.Metric {
+				assert.Equal(t, float64(value), x.GetCounter().GetValue())
+
+				for _, label := range x.Label {
+					if *label.Name == "healthcheck_result" {
+						assert.Equal(t, outcome, *label.Value)
+					}
+				}
+			}
+		}
+	}
+}

--- a/op/opstatus.go
+++ b/op/opstatus.go
@@ -46,18 +46,7 @@ func (s *Status) AddCheckerWithMetrics(name string, checkerFunc func(cr *CheckRe
 		Name: checkCounterName,
 		Help: "Counts the number of times the check was healthy",
 	}, []string{"healthcheck_result"})
-	// healthyCheckCounter := prometheus.NewCounter(prometheus.CounterOpts{
-	// 	Name: checkCounterName + "_" + healthy,
-	// 	Help: "Counts the number of times the check was healthy",
-	// })
-	// unhealthyCheckCounter := prometheus.NewCounter(prometheus.CounterOpts{
-	// 	Name: checkCounterName + "_" + unhealthy,
-	// 	Help: "Counts the number of times the check was unhealthy",
-	// })
-	// degradedhealthCheckCounter := prometheus.NewCounter(prometheus.CounterOpts{
-	// 	Name: checkCounterName + "_" + degraded,
-	// 	Help: "Counts the number of times the check was degraded",
-	// })
+
 	s.AddMetrics(checkCounterVec)
 
 	s.checkers = append(s.checkers, checker{name, checkerFunc, checkCounterVec})


### PR DESCRIPTION
It would be great to be able to use healthchecks in order to do a few things 
- In the case where the healthchecks check third party connectivity / synthetic checks the metrics will be useful to paint a good picture of reliability of the third party service
- In the case where the checks test connectivity with underlying datastores, the meters will help provide visibility of how reliable the datastores are
- etc.

Because of having to test AddCHeckerWithMetrics method, there was a need to bring in prometheus/model package.