### PR TITLE
Run each check concurrently, fixes #1

### DIFF
--- a/op/opstatus.go
+++ b/op/opstatus.go
@@ -100,7 +100,8 @@ func (s *Status) Ready(f func() bool) *Status {
 	return s
 }
 
-// Check returns the current health state of the application.
+// Check returns the current health state of the application. Each checker is
+// run concurrently.
 func (s *Status) Check() HealthResult {
 	hr := HealthResult{
 		Name:         s.name,

--- a/op/opstatus.go
+++ b/op/opstatus.go
@@ -108,7 +108,7 @@ func (s *Status) Check() HealthResult {
 		CheckResults: make([]healthResultEntry, len(s.checkers)),
 	}
 
-	wg := &sync.WaitGroup{}
+	var wg sync.WaitGroup
 	wg.Add(len(s.checkers))
 
 	for i, ch := range s.checkers {


### PR DESCRIPTION
```shell
go test ./... -cover -race
?   	github.com/utilitywarehouse/go-operational	[no test files]
ok  	github.com/utilitywarehouse/go-operational/op	1.086s	coverage: 97.4% of statements
```

