### PR TITLE
Allow a health check to be replace or removed

### DIFF
--- a/op/health_test.go
+++ b/op/health_test.go
@@ -1,8 +1,9 @@
 package op
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHealthCheck(t *testing.T) {
@@ -12,9 +13,16 @@ func TestHealthCheck(t *testing.T) {
 		AddChecker("check the foo bar", func(cr *CheckResponse) {
 			cr.Healthy("check command completed ok")
 		}).
+		AddChecker("check the foo bar", func(cr *CheckResponse) {
+			cr.Healthy("check command completed ok")
+		}).
 		AddChecker("check the bar baz", func(cr *CheckResponse) {
 			cr.Degraded("thing failed", "fix the thing")
-		})
+		}).
+		AddChecker("should be removed", func(cr *CheckResponse) {
+			cr.Healthy("check command completed ok")
+		}).
+		RemoveChecker("should be removed")
 
 	result := hc.Check()
 
@@ -24,17 +32,17 @@ func TestHealthCheck(t *testing.T) {
 		Health:      "degraded",
 		CheckResults: []healthResultEntry{
 			{
-				Name:   "check the foo bar",
-				Health: "healthy",
-				Output: "check command completed ok",
-				Action: "",
-				Impact: "",
-			},
-			{
 				Name:   "check the bar baz",
 				Health: "degraded",
 				Output: "thing failed",
 				Action: "fix the thing",
+				Impact: "",
+			},
+			{
+				Name:   "check the foo bar",
+				Health: "healthy",
+				Output: "check command completed ok",
+				Action: "",
 				Impact: "",
 			},
 		},

--- a/op/health_with_metrics_test.go
+++ b/op/health_with_metrics_test.go
@@ -1,11 +1,10 @@
 package op
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
-
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,10 +28,10 @@ func TestHealthCheckWithMetrics(t *testing.T) {
 		Health:      "unhealthy",
 		CheckResults: []healthResultEntry{
 			{
-				Name:   "check mongo",
-				Health: "healthy",
-				Output: "check command completed ok",
-				Action: "",
+				Name:   "check api",
+				Health: "degraded",
+				Output: "thing failed",
+				Action: "fix the thing",
 				Impact: "",
 			},
 			{
@@ -43,10 +42,10 @@ func TestHealthCheckWithMetrics(t *testing.T) {
 				Impact: "very bad",
 			},
 			{
-				Name:   "check api",
-				Health: "degraded",
-				Output: "thing failed",
-				Action: "fix the thing",
+				Name:   "check mongo",
+				Health: "healthy",
+				Output: "check command completed ok",
+				Action: "",
 				Impact: "",
 			},
 		},
@@ -66,7 +65,6 @@ func TestHealthCheckWithMetrics(t *testing.T) {
 	assertMetricLabelsAndValue(t, mfs, "check_api", healthy, 0)
 	assertMetricLabelsAndValue(t, mfs, "check_api", degraded, 1)
 	assertMetricLabelsAndValue(t, mfs, "check_api", unhealthy, 0)
-
 }
 
 func assertMetricLabelsAndValue(t *testing.T, mfs []*dto.MetricFamily, checkname string, outcome string, value int) {


### PR DESCRIPTION
There doesn't seem to be a use case where you'd want to add a health check with the same name multiple times. However, before this PR checkers are appended and serialised to JSON.

The PR makes it simpler for the calling application. For example, a connection fails and you want to re-instantiate a new one. The application has to deal with a health already added, and the `func(resp *CheckResponse)` needs to call the the new connection. Now, I can just re-add the checker, replacing the old one.

Removal of a checker was added because we have some dynamic use cases.