### PR TITLE
Remove a checker func added by AddChecker

### DIFF
--- a/op/health_test.go
+++ b/op/health_test.go
@@ -1,8 +1,9 @@
 package op
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHealthCheck(t *testing.T) {
@@ -14,7 +15,14 @@ func TestHealthCheck(t *testing.T) {
 		}).
 		AddChecker("check the bar baz", func(cr *CheckResponse) {
 			cr.Degraded("thing failed", "fix the thing")
-		})
+		}).
+		AddChecker("hello", func(cr *CheckResponse) {
+			cr.Healthy("check hello command")
+		}).
+		AddChecker("hello", func(cr *CheckResponse) {
+			cr.Healthy("check hello command")
+		}).
+		RemoveCheckers("hello")
 
 	result := hc.Check()
 

--- a/op/opstatus.go
+++ b/op/opstatus.go
@@ -49,6 +49,19 @@ func (s *Status) AddChecker(name string, checkerFunc func(cr *CheckResponse)) *S
 	return s
 }
 
+// RemoveCheckers will remove health check functions added by AddChecker.
+// If multiple checks have been added with the same name, these will all be removed.
+func (s *Status) RemoveCheckers(name string) *Status {
+	var checkers []checker
+	for _, ch := range s.checkers {
+		if ch.name != name {
+			checkers = append(checkers, ch)
+		}
+	}
+	s.checkers = checkers
+	return s
+}
+
 // AddMetrics registers prometheus metrics to be exopsed on the /__/metrics endpoint
 // Adding the same metric twice will result in a panic
 func (s *Status) AddMetrics(cs ...prometheus.Collector) *Status {


### PR DESCRIPTION
Follow up to https://github.com/utilitywarehouse/go-operational/pull/9 but simplifies so as not to break the current semantics.