### PR TITLE
register pprof handlers by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,8 @@ func main() {
 	http.ListenAndServe(":8080", nil)
 }
 ```
+
+PPROF
+-------
+By default go operational will bind PPROFs handlers to the path `/__/extended/pprof/`
+We also overload the default mux in order to stop the handlers binding to the default paths. 

--- a/op/handlers.go
+++ b/op/handlers.go
@@ -66,6 +66,9 @@ func NewHandler(os *Status) http.Handler {
 	m.Handle("/__/ready", newReadyHandler(os))
 	m.Handle("/__/metrics", promhttp.Handler())
 
+	// Overload default mux in order to stop pprof binding handlers to it
+	http.DefaultServeMux = http.NewServeMux()
+
 	// Register PPROF handlers
 	m.Handle("/__/extended/pprof/", http.HandlerFunc(pprof.Index))
 	m.Handle("/__/extended/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))

--- a/op/handlers.go
+++ b/op/handlers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/http/pprof"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -64,5 +65,19 @@ func NewHandler(os *Status) http.Handler {
 	m.Handle("/__/health", newHealthCheckHandler(os))
 	m.Handle("/__/ready", newReadyHandler(os))
 	m.Handle("/__/metrics", promhttp.Handler())
+
+	// Register PPROF handlers
+	m.Handle("/__/extended/pprof/", http.HandlerFunc(pprof.Index))
+	m.Handle("/__/extended/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+	m.Handle("/__/extended/pprof/profile", http.HandlerFunc(pprof.Profile))
+	m.Handle("/__/extended/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+	m.Handle("/__/extended/pprof/trace", http.HandlerFunc(pprof.Trace))
+	m.Handle("/__/extended/pprof/goroutine", pprof.Handler("goroutine"))
+	m.Handle("/__/extended/pprof/heap", pprof.Handler("heap"))
+	m.Handle("/__/extended/pprof/threadcreate", pprof.Handler("threadcreate"))
+	m.Handle("/__/extended/pprof/block", pprof.Handler("block"))
+	m.Handle("/__/extended/pprof/mutex", pprof.Handler("mutex"))
+	m.Handle("/__/extended/pprof/allocs", pprof.Handler("allocs"))
+
 	return m
 }


### PR DESCRIPTION
Opening to start a conversation and doesn't necessarily depict the final implementation.

We have a growing number of use cases for on demand profiling/tracing and this seems like the most sensible way to achieve that with little or no effort.

Taking our rating pipeline as an example the idea is that we will make use of existing operational and standardised metrics in order to pin down bottlenecks to a single service and/or RPC followed by pprof in order to profile, identify and optimise functions within those calls/handlers.

This approach alleviates the need for us to introduce a dependency on a tracing framework and does so with little or no overhead to go operational.

Related to https://github.com/utilitywarehouse/operational-endpoints-spec/pull/9